### PR TITLE
docs: PulseEngine branding and terminology alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 &nbsp;
 
-Bazel rules for Rocq/Coq theorem proving and Rust formal verification with hermetic toolchain support via [Nix](https://nixos.org/).
+Bazel rules for Rocq theorem proving and Rust formal verification with hermetic toolchain support via [Nix](https://nixos.org/).
 
 > [!NOTE]
 > Part of the PulseEngine toolchain. Powers the mechanized proofs in Meld, Loom, and PulseEngine verification infrastructure.


### PR DESCRIPTION
## Summary

- Align README with PulseEngine visual identity (badges, headers, footer)
- Replace "Rocq/Coq" with "Rocq" (Coq was renamed, no need to carry old name)

## Test plan

- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)