### PR TITLE
chore: bump Rust nightly, nixpkgs, align Rocq 9.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
     - name: Install Rust nightly
       uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly-2024-12-01
+        toolchain: nightly-2024-12-07
         components: rustc-dev, rust-src, llvm-tools-preview
 
     - name: Set Rust library paths
       run: |
         # Get Rust sysroot and add its lib directory to library paths
-        RUST_SYSROOT=$(rustc +nightly-2024-12-01 --print sysroot)
+        RUST_SYSROOT=$(rustc +nightly-2024-12-07 --print sysroot)
         echo "RUST_SYSROOT=$RUST_SYSROOT"
         ls -la $RUST_SYSROOT/lib/ | head -10
         echo "LIBRARY_PATH=$RUST_SYSROOT/lib:$LIBRARY_PATH" >> $GITHUB_ENV

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,8 +38,8 @@ nix_repo.github(
     name = "nixpkgs",
     org = "NixOS",
     repo = "nixpkgs",
-    # nixos-unstable with Rocq 9.0.1, coq-hammer, coqutil
-    commit = "88d3861acdd3d2f0e361767018218e51810df8a1",
+    # nixos-unstable with Rocq 9.0.1, coq-hammer, coqutil (2026-03-06)
+    commit = "aca4d95fce4914b3892661bcb80b8087293536c6",
     sha256 = "",  # Will be computed on first fetch
 )
 use_repo(nix_repo, "nixpkgs")
@@ -47,7 +47,7 @@ use_repo(nix_repo, "nixpkgs")
 # Rocq toolchain extension - uses nixpkgs for hermetic Rocq/Coq
 rocq = use_extension("//rocq:extensions.bzl", "rocq")
 rocq.toolchain(
-    version = "9.0",  # Rocq 9.0 (required for real RocqOfRust library)
+    version = "9.0",  # Rocq 9.0.1 (required for real RocqOfRust library)
     strategy = "nix",   # Hermetic nix-based installation
     with_rocq_of_rust_deps = True,  # Include coqutil, hammer, smpl
 )

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 On Linux, rocq-of-rust requires Rust nightly with rustc internals:
 
 ```bash
-rustup toolchain install nightly-2024-12-01
-rustup component add rustc-dev rust-src --toolchain nightly-2024-12-01
-export LIBRARY_PATH="$(rustc +nightly-2024-12-01 --print sysroot)/lib:$LIBRARY_PATH"
+rustup toolchain install nightly-2024-12-07
+rustup component add rustc-dev rust-src --toolchain nightly-2024-12-07
+export LIBRARY_PATH="$(rustc +nightly-2024-12-07 --print sysroot)/lib:$LIBRARY_PATH"
 ```
 
 On macOS, Nix provides the complete Rust toolchain automatically.
@@ -151,7 +151,7 @@ Test rule that verifies proofs compile successfully.
 
 | Component | Description |
 |-----------|-------------|
-| Rocq 9.0 | Core theorem prover |
+| Rocq 9.0.1 | Core theorem prover |
 | coqutil | Utility library |
 | Hammer | Automated proof tactics |
 | smpl | Simplification tactics |
@@ -171,13 +171,13 @@ Test rule that verifies proofs compile successfully.
 ### "unable to find library -lLLVM-19-rust-*" (Linux)
 
 ```bash
-export LIBRARY_PATH="$(rustc +nightly-2024-12-01 --print sysroot)/lib:$LIBRARY_PATH"
+export LIBRARY_PATH="$(rustc +nightly-2024-12-07 --print sysroot)/lib:$LIBRARY_PATH"
 ```
 
 ### "rustc-dev component not found"
 
 ```bash
-rustup component add rustc-dev rust-src --toolchain nightly-2024-12-01
+rustup component add rustc-dev rust-src --toolchain nightly-2024-12-07
 ```
 
 ## Example

--- a/coq_of_rust/extensions.bzl
+++ b/coq_of_rust/extensions.bzl
@@ -16,7 +16,7 @@ _RocqOfRustToolchainTag = tag_class(
         ),
         "rust_nightly": attr.string(
             doc = "Rust nightly version to use",
-            default = "nightly-2024-12-01",
+            default = "nightly-2024-12-07",
         ),
         "use_real_library": attr.bool(
             doc = "Use real RocqOfRust library (requires nixpkgs deps: coqutil, hammer, smpl)",
@@ -49,7 +49,7 @@ def _rocq_of_rust_impl(module_ctx):
     else:
         commit = ""  # Uses pinned default in repository.bzl
         sha256 = ""
-        rust_nightly = "nightly-2024-12-01"
+        rust_nightly = "nightly-2024-12-07"
         use_real_library = False
         fail_on_error = True
 

--- a/coq_of_rust/private/repository.bzl
+++ b/coq_of_rust/private/repository.bzl
@@ -8,7 +8,7 @@ Building with cargo directly avoids crate_universe issues with edition2024 crate
 _DEFAULT_COMMIT = "858907dbee116c51d7c6e87511bf5f92d6432ba4"
 _DEFAULT_SHA256 = "2fcfb09c3d14091f021b3aa7876ada55a29708c7f27f6646d3ebee162975bf61"
 _DEFAULT_REPO = "https://github.com/formal-land/rocq-of-rust"
-_DEFAULT_NIGHTLY = "nightly-2024-12-01"
+_DEFAULT_NIGHTLY = "nightly-2024-12-07"
 
 def _rocq_of_rust_source_impl(repository_ctx):
     """Download and build rocq-of-rust from source."""
@@ -326,12 +326,12 @@ def _create_placeholder(repository_ctx, reason):
 rocq-of-rust build failed: {}
 
 To fix this, ensure you have:
-1. Rust nightly toolchain: rustup toolchain install nightly-2024-12-01
-2. Required components: rustup component add rustc-dev rust-src --toolchain nightly-2024-12-01
+1. Rust nightly toolchain: rustup toolchain install nightly-2024-12-07
+2. Required components: rustup component add rustc-dev rust-src --toolchain nightly-2024-12-07
 3. LIBRARY_PATH set to include Rust's lib directory (for LLVM)
 
 On macOS, this usually works automatically via nix.
-On Linux, you may need: export LIBRARY_PATH=$(rustc +nightly-2024-12-01 --print sysroot)/lib
+On Linux, you may need: export LIBRARY_PATH=$(rustc +nightly-2024-12-07 --print sysroot)/lib
 
 To use placeholder mode instead (not recommended for production):
   rocq_of_rust.toolchain(fail_on_error = False)

--- a/rocq/extensions.bzl
+++ b/rocq/extensions.bzl
@@ -1,7 +1,7 @@
 """Module extensions for using rules_rocq with bzlmod.
 
 Provides Rocq/Coq toolchain setup using nixpkgs for hermetic builds.
-Supports Rocq 9.0+ and includes required external packages for rocq-of-rust.
+Supports Rocq 9.0.1+ and includes required external packages for rocq-of-rust.
 
 This extension creates its own nixpkgs repository internally for bzlmod compatibility.
 """
@@ -9,8 +9,8 @@ This extension creates its own nixpkgs repository internally for bzlmod compatib
 load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package", "nixpkgs_local_repository")
 load("//rocq/private:smpl_repository.bzl", "smpl_source")
 
-# Default nixpkgs commit (nixos-unstable with Rocq 9.0)
-_DEFAULT_NIXPKGS_COMMIT = "88d3861acdd3d2f0e361767018218e51810df8a1"
+# Default nixpkgs commit (nixos-unstable with Rocq 9.0.1)
+_DEFAULT_NIXPKGS_COMMIT = "aca4d95fce4914b3892661bcb80b8087293536c6"
 
 # Tag classes for Rocq toolchain configuration
 _RocqToolchainTag = tag_class(

--- a/rocq/private/smpl_repository.bzl
+++ b/rocq/private/smpl_repository.bzl
@@ -280,7 +280,7 @@ smpl_source = repository_rule(
             doc = "SHA256 of the source archive",
         ),
         "nixpkgs_commit": attr.string(
-            default = "88d3861acdd3d2f0e361767018218e51810df8a1",
+            default = "aca4d95fce4914b3892661bcb80b8087293536c6",
             doc = "Nixpkgs commit hash for reproducible builds",
         ),
     },


### PR DESCRIPTION
## Summary

- Fix Rust nightly mismatch: Bazel-side pin was `2024-12-01` but upstream rocq-of-rust and `flake.nix` both use `2024-12-07`
- Update nixpkgs pin from `88d3861a` (Jan 21) to `aca4d95f` (Mar 6, 2026) for fresher packages including Rocq 9.0.1
- Update docs and comments to reflect Rocq 9.0.1 (patch release, same `coq_9_0` nix attribute)

## Details

The `nightly-2024-12-01` pin in the Bazel rules didn't match upstream rocq-of-rust's `rust-toolchain` file (`nightly-2024-12-07`) or this project's own `flake.nix`. This aligns all references to `nightly-2024-12-07`.

The nixpkgs pin was ~6 weeks stale. Updated to a recent `nixos-unstable` commit. The `coq_9_0` attribute now resolves to Rocq 9.0.1 (patch release).

## Test plan

- [ ] CI: verify-rules job passes (rules load)
- [ ] CI: Linux build with nix toolchain passes
- [ ] CI: macOS build passes
- [ ] CI: buildifier check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)