### PR TITLE
chore: bump nixpkgs to 2026-04-01

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,8 +38,8 @@ nix_repo.github(
     name = "nixpkgs",
     org = "NixOS",
     repo = "nixpkgs",
-    # nixos-unstable with Rocq 9.0.1, coq-hammer, coqutil (2026-03-06)
-    commit = "aca4d95fce4914b3892661bcb80b8087293536c6",
+    # nixos-unstable with Rocq 9.0.1, coq-hammer, coqutil (2026-04-01)
+    commit = "6201e203d09599479a3b3450ed24fa81537ebc4e",
     sha256 = "",  # Will be computed on first fetch
 )
 use_repo(nix_repo, "nixpkgs")

--- a/examples/rust_to_rocq/MODULE.bazel
+++ b/examples/rust_to_rocq/MODULE.bazel
@@ -27,8 +27,8 @@ nix_repo.github(
     name = "nixpkgs",
     org = "NixOS",
     repo = "nixpkgs",
-    # nixos-unstable with Rocq 9.0.1
-    commit = "aca4d95fce4914b3892661bcb80b8087293536c6",
+    # nixos-unstable with Rocq 9.0.1 (2026-04-01)
+    commit = "6201e203d09599479a3b3450ed24fa81537ebc4e",
     sha256 = "",
 )
 use_repo(nix_repo, "nixpkgs")

--- a/rocq/extensions.bzl
+++ b/rocq/extensions.bzl
@@ -10,7 +10,7 @@ load("@rules_nixpkgs_core//:nixpkgs.bzl", "nixpkgs_package", "nixpkgs_local_repo
 load("//rocq/private:smpl_repository.bzl", "smpl_source")
 
 # Default nixpkgs commit (nixos-unstable with Rocq 9.0.1)
-_DEFAULT_NIXPKGS_COMMIT = "aca4d95fce4914b3892661bcb80b8087293536c6"
+_DEFAULT_NIXPKGS_COMMIT = "6201e203d09599479a3b3450ed24fa81537ebc4e"
 
 # Tag classes for Rocq toolchain configuration
 _RocqToolchainTag = tag_class(

--- a/rocq/private/smpl_repository.bzl
+++ b/rocq/private/smpl_repository.bzl
@@ -280,7 +280,7 @@ smpl_source = repository_rule(
             doc = "SHA256 of the source archive",
         ),
         "nixpkgs_commit": attr.string(
-            default = "aca4d95fce4914b3892661bcb80b8087293536c6",
+            default = "6201e203d09599479a3b3450ed24fa81537ebc4e",
             doc = "Nixpkgs commit hash for reproducible builds",
         ),
     },


### PR DESCRIPTION
## Summary
- Bump nixpkgs from aca4d95 (Mar 6) → 6201e20 (Apr 1)
- Updated in MODULE.bazel, extensions.bzl, example MODULE.bazel, smpl_repository.bzl

## Test plan
- [ ] CI passes — Rocq 9.0.1 + coqutil + hammer still resolve from updated nixpkgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)