### PR TITLE
ci: migrate 2 of 9 ci jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   # Basic loading verification (fast, no nix required)
   verify-rules:
     name: Verify Rules Load
+    # Stays on ubuntu-latest: uses bazelbuild/setup-bazelisk; Bazel is not pre-installed on smithy.
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +43,7 @@ jobs:
   # Full build with nix toolchain (Linux)
   build:
     name: Build Example (Linux)
+    # Stays on ubuntu-latest: needs Nix + Bazel + Rocq toolchain, none of which are on smithy.
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -122,6 +124,7 @@ jobs:
   # macOS build
   build-macos:
     name: Build Example (macOS)
+    # Stays on macos-latest: smithy fleet is Linux-only.
     runs-on: macos-latest
     permissions:
       id-token: write
@@ -175,7 +178,7 @@ jobs:
   # Buildifier check
   buildifier:
     name: Buildifier Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_comprehensive.yml
+++ b/.github/workflows/ci_comprehensive.yml
@@ -11,6 +11,7 @@ jobs:
   # Multi-platform verification
   verify-multiplatform:
     name: Verify Rules (${{ matrix.os }})
+    # Stays on hosted: needs Bazel (not on smithy) and macOS in matrix (smithy is Linux-only).
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   docs:
     name: Documentation Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     
     steps:
     - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   publish:
+    # Stays on hosted: reusable workflow from bazel-contrib pins its own runner; not callable to smithy.
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.1.0
     with:
       tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}

--- a/.github/workflows/quick_test.yml
+++ b/.github/workflows/quick_test.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   quick-test:
     name: Quick Test
+    # Stays on ubuntu-latest: uses bazelbuild/setup-bazelisk and runs bazel; Bazel not on smithy.
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   release:
     name: Create Release
+    # Stays on ubuntu-latest: build step runs `bazel build`; Bazel not on smithy.
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## Summary

This is a Bazel rules repo bridging Rocq (Coq) and Rust. Per the
[smithy migration playbook](https://github.com/pulseengine/smithy/blob/main/docs/migration-playbook.md),
neither Bazel nor Coq/Rocq are installed on the smithy fleet, so the
migrable surface is small: every job that compiles or queries Bazel
targets stays on `ubuntu-latest`, and the macOS matrix entry stays
on `macos-latest` (smithy is Linux-only). Following the same
per-job approach as pulseengine/spar#201, pulseengine/rivet#262, and
pulseengine/kiln#247.

## Coverage

| Class      | Jobs                                            |
|------------|-------------------------------------------------|
| `light`    | `buildifier` (ci.yml), `docs` (docs.yml)        |
| (hosted)   | 7 others (Bazel/Nix/Rocq/macOS/reusable)        |

## Stays on hosted (each commented in-place)

| Job (file) | Reason |
|---|---|
| `verify-rules` (ci.yml) | runs `bazel query`; Bazel not on smithy |
| `build` (ci.yml) | needs Nix + Bazel + Rocq toolchain |
| `build-macos` (ci.yml) | smithy is Linux-only |
| `verify-multiplatform` (ci_comprehensive.yml) | Bazel + macOS matrix |
| `quick-test` (quick_test.yml) | runs `bazel query` |
| `release` (release.yml) | release step runs `bazel build` |
| `publish` (publish.yml) | reusable workflow from `bazel-contrib` |

## Workarounds applied

None. The two migrated jobs are clean drop-ins:

- **buildifier**: curls a static `buildifier-linux-amd64` binary and
  runs `--mode=check -r .`. No sudo, no apt, no Bazel invocation
  (the `setup-bazelisk` step is harmless on smithy and is left
  in-place to keep the diff minimal).
- **docs**: shell `grep` checks on README plus
  `npm install -g markdown-link-check`. Smithy ships Node LTS via
  nvm with a writable global prefix, so the global install needs no
  sudo.

## Test plan

- [ ] CI run completes; `buildifier` and `docs` jobs land on `light` smithy runners
- [ ] No EACCES events in smithy's `journalctl -u smithy-trace-eacces.service` during the run
- [ ] Hosted jobs (`verify-rules`, `build`, `build-macos`, `verify-multiplatform`, `quick-test`) continue to pass as before
- [ ] `npm install -g markdown-link-check` resolves to nvm's prefix (no permission error)

## Rollback

Revert this commit. Every job's `runs-on:` flips back to
`ubuntu-latest` / `macos-latest` and the next run uses GitHub-hosted
compute.

## Follow-ups (out of scope here)

- `Bazel`, `Coq/Rocq`, and `Nix` are tracked as open items in the
  smithy playbook's "out of scope" table. When smithy's toolchains
  role grows them, the seven hosted jobs above become candidates
  for migration in a follow-up PR.