### PR TITLE
fix(readme): replace flat verification badge with honest Rocq badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 &nbsp;
 
 ![Bazel](https://img.shields.io/badge/Bazel-43A047?style=flat-square&logo=bazel&logoColor=white&labelColor=1a1b27)
-![Formally Verified](https://img.shields.io/badge/Formally_Verified-00C853?style=flat-square&logoColor=white&labelColor=1a1b27)
+![Rocq](https://img.shields.io/badge/Rocq-9.0-A44E9C?style=flat-square&labelColor=1a1b27)
 ![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue?style=flat-square&labelColor=1a1b27)
 
 </div>


### PR DESCRIPTION
## Summary
- The README carried a flat green "Formally Verified" badge, but the repo is Bazel/Nix plumbing wiring Rocq 9.0 + rocq-of-rust into builds — the only `.v` proof in the tree is an example (`examples/rust_to_rocq/point_proofs.v`), not a proof about the rules themselves.
- Replaces it with a technique-named "Rocq" badge, matching the precedent set by sibling `rules_lean` (no flat verification badge).

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MptgyfLZuHYCbfpq1zDey